### PR TITLE
Fix invalid texture sizes

### DIFF
--- a/src/modules/scene-objects/earth.js
+++ b/src/modules/scene-objects/earth.js
@@ -23,7 +23,12 @@ export default class Earth extends SceneObject {
 
         const emptySphere    = new THREE.SphereBufferGeometry(Earth.radius - 0.02, 64, 64);
         const fallbackSphere = new THREE.SphereBufferGeometry(Earth.radius - 0.01, 64, 64);
-        const sphere         = new THREE.SphereBufferGeometry(Earth.radius,        64, 64);
+
+        // The Google Chrome doesn't support big textures now. So we need to split
+        // the big texture of size 8192x4096 into two the textures of size 4096x4096.
+        // This is a bad solution, but it works in this case.
+        const spherePart1 = new THREE.SphereBufferGeometry(Earth.radius, 64, 64, 0, Math.PI);
+        const spherePart2 = new THREE.SphereBufferGeometry(Earth.radius, 64, 64, 0, Math.PI);
 
         const emptyMaterial = new THREE.MeshBasicMaterial({
             color: 0x0d47a1,
@@ -35,7 +40,13 @@ export default class Earth extends SceneObject {
             opacity: 0
         });
 
-        const material = new THREE.MeshBasicMaterial({
+        const materialPart1 = new THREE.MeshBasicMaterial({
+            map: new UpdatableTexture(),
+            transparent: true,
+            opacity: 0
+        });
+
+        const materialPart2 = new THREE.MeshBasicMaterial({
             map: new UpdatableTexture(),
             transparent: true,
             opacity: 0
@@ -61,17 +72,20 @@ export default class Earth extends SceneObject {
                             to: 1,
                             duration: 7000,
                             change: (value) => {
-                                material.opacity = value;
+                                materialPart1.opacity = value;
+                                materialPart2.opacity = value;
                             }
                         });
 
-                        material.map.setRenderer(renderer);
-                        material.map.setSize(texture.width, texture.height);
+                        materialPart1.map.setRenderer(renderer);
+                        materialPart1.map.setSize(texture.width, texture.height);
+                        materialPart2.map.setRenderer(renderer);
+                        materialPart2.map.setSize(texture.width, texture.height);
 
                         const partsX = texture.width / texture.partSize;
                         const partsY = texture.height / texture.partSize;
 
-                        for (let x = 0; x < partsX; x++) {
+                        for (let x = 0; x < partsX * 2; x++) {
                             for (let y = 0; y < partsY; y++) {
                                 const url = texture.urlTemplate.replace('{x}', x).replace('{y}', y);
 
@@ -84,11 +98,19 @@ export default class Earth extends SceneObject {
                                     // and the user will be able to see some FPS reduction,
                                     // but without hardcore lags.
                                     setTimeout(() => {
-                                        material.map.update(
-                                            partImage,
-                                            x * texture.partSize,
-                                            y * texture.partSize
-                                        );
+                                        if (x < partsX) {
+                                            materialPart1.map.update(
+                                                partImage,
+                                                x * texture.partSize,
+                                                y * texture.partSize
+                                            );
+                                        } else {
+                                            materialPart2.map.update(
+                                                partImage,
+                                                (x - partsX) * texture.partSize,
+                                                y * texture.partSize
+                                            );
+                                        }
                                     }, 5000 * Math.random());
                                 });
                             }
@@ -100,7 +122,12 @@ export default class Earth extends SceneObject {
 
         group.add(new THREE.Mesh(emptySphere, emptyMaterial));
         group.add(new THREE.Mesh(fallbackSphere, fallbackMaterial));
-        group.add(new THREE.Mesh(sphere, material));
+        group.add(new THREE.Mesh(spherePart1, materialPart1));
+
+        const part2 = new THREE.Mesh(spherePart2, materialPart2);
+
+        part2.rotation.y = Math.PI;
+        group.add(part2);
 
         return group;
     }

--- a/src/settings.js
+++ b/src/settings.js
@@ -11,7 +11,7 @@ const earth = {
     texture: {
         urlTemplate: './images/earth-{x}-{y}.jpg',
         partSize: 1024,
-        width: 8192,
+        width: 4096,
         height: 4096
     }
 };
@@ -26,7 +26,7 @@ const stars = {
     texture: {
         urlTemplate: './images/stars-{x}-{y}.jpg',
         partSize: 1024,
-        width: 8192,
+        width: 4096,
         height: 4096
     }
 };


### PR DESCRIPTION
Fixes #1 

## Proposed Changes
  - Split the Earth and the Stars into two parts with the smaller textures of size 4096x4096
